### PR TITLE
benchmarks: Add more runners

### DIFF
--- a/benchmarks/report.md
+++ b/benchmarks/report.md
@@ -1,69 +1,134 @@
-## Benchmark Report
+# Benchmark Report
 The benchmarks run on a 13" MacBook Pro (2020) with a 1.4 GHz Quad-Core i5 and 16GB 2133MHz RAM.
 
-Based on query-json 0.2.1
+This benchmark consists in steps: one using [hyperfine](https://github.com/sharkdp/hyperfine) which evaluates the simple identity of each tool, to check boot time performance and the other running a time with a different kind of queries on a set of different json file sizes.
 
-# Using [hyperfine](https://github.com/sharkdp/hyperfine)
+Executing `$ ./benchmarks/run.sh` runs both steps.
 
-`$ hyperfine --warmup 10 'query-json . esy.json' 'jq . esy.json'`
+## Output
+
+`$ ./benchmarks/run.sh`
+
+query-json: 0.5.8
+jq: jq-1.6
+faq: 0.0.6
+fx: 20.0.2
+
+### Benchmark #1: jq . esy.json
+```
+  Time (mean ± σ):      27.6 ms ±   1.0 ms    [User: 25.4 ms, System: 1.2 ms]
+  Range (min … max):    26.5 ms …  32.1 ms    71 runs
+```
+
 ### Benchmark #1: query-json . esy.json
 ```
-Time  (mean ± σ):      6.7 ms ±   0.2 ms    [User: 3.4 ms, System: 2.2 ms]
-Range (min … max):     6.3 ms …   7.6 ms    291 runs
+  Time (mean ± σ):       7.8 ms ±   0.2 ms    [User: 3.4 ms, System: 2.1 ms]
+  Range (min … max):     7.3 ms …   8.9 ms    267 runs
 ```
 ### Benchmark #2: jq . esy.json
 ```
-Time  (mean ± σ):     28.0 ms ±   1.3 ms    [User: 25.6 ms, System: 1.3 ms]
-Range (min … max):    26.8 ms …  36.5 ms    94 runs
+  Time (mean ± σ):      27.6 ms ±   1.1 ms    [User: 25.3 ms, System: 1.2 ms]
+  Range (min … max):    26.4 ms …  34.5 ms    98 runs
+```
+## **Summary** `query-json . esy.json` ran 3.56 ± 0.18 times faster than `jq . esy.json`
+
+### Benchmark #1: faq . esy.json
+```
+  Time (mean ± σ):      55.1 ms ±   0.6 ms    [User: 54.5 ms, System: 5.1 ms]
+  Range (min … max):    53.9 ms …  57.2 ms    43 runs
+```
+### Benchmark #1: query-json . esy.json
+```
+  Time (mean ± σ):       7.8 ms ±   0.2 ms    [User: 3.4 ms, System: 2.1 ms]
+  Range (min … max):     7.3 ms …   8.9 ms    280 runs
+```
+### Benchmark #2: faq . esy.json
+```
+  Time (mean ± σ):      55.2 ms ±   0.7 ms    [User: 54.8 ms, System: 5.2 ms]
+  Range (min … max):    53.9 ms …  57.2 ms    51 runs
+```
+## **Summary** `query-json . esy.json` ran 7.11 ± 0.23 times faster than `faq . esy.json`
+
+### Benchmark #1: fx esy.json .
+```
+  Time (mean ± σ):      60.5 ms ±   1.8 ms    [User: 48.6 ms, System: 13.3 ms]
+  Range (min … max):    59.1 ms …  70.9 ms    40 runs
+```
+### Benchmark #1: query-json . esy.json
+```
+  Time (mean ± σ):       7.8 ms ±   0.2 ms    [User: 3.4 ms, System: 2.1 ms]
+  Range (min … max):     7.4 ms …   8.8 ms    256 runs
+```
+### Benchmark #2: fx esy.json .
+```
+  Time (mean ± σ):      60.3 ms ±   0.6 ms    [User: 48.5 ms, System: 12.9 ms]
+  Range (min … max):    59.3 ms …  62.1 ms    47 runs
+```
+## **Summary** `query-json . esy.json` ran 7.73 ± 0.24 times faster than `fx esy.json .`
+
+---
+
+## Running [run.sh](./run.sh)
+
+### Select an attribute (`.first.id`) on a small (4kb) JSON file
+
+```
+query-json        0.00 real         0.00 user         0.00 sys
+jq                0.02 real         0.02 user         0.00 sys
+faq               0.05 real         0.05 user         0.00 sys
+fx                0.06 real         0.04 user         0.01 sys
 ```
 
-## Summary
-'query-json . esy.json' **ran 4.15 ± 0.23 times** faster than 'jq . esy.json'
-
-# Using a handmade script: [./run.sh](./run.sh)
-Times are given in CPU time (seconds), wall-clock times may deviate by ± 0.1s.
-
-`$ ./benchmarks/run.sh`
-### Select an attribute on a small (4kb) JSON file
+### Select an attribute (`.`) on a medium (132k) JSON file
 ```
-jq          0.03 real         0.02 user         0.00 sys
-query-json  0.00 real         0.00 user         0.00 sys
+query-json        0.02 real         0.01 user         0.00 sys
+jq                0.04 real         0.03 user         0.00 sys
+faq               0.07 real         0.08 user         0.00 sys
+fx                0.11 real         0.12 user         0.02 sys
 ```
-### Select an attribute on a medium (132k) JSON file
+### Map an attribute (`map(.)`) on a big JSON (604k) file
 ```
-jq          0.04 real         0.03 user         0.00 sys
-query-json  0.02 real         0.01 user         0.00 sys
-```
-### Select an attribute on a big JSON (604k) file
-```
-jq          0.08 real         0.07 user         0.00 sys
-query-json  0.06 real         0.05 user         0.00 sys
+query-json        0.07 real         0.06 user         0.00 sys
+jq                0.08 real         0.07 user         0.00 sys
+faq               0.12 real         0.14 user         0.01 sys
+fx                0.17 real         0.20 user         0.02 sys
 ```
 
-### Simple operation on a small (4kb) JSON file
+### Simple operation (`.second.store.books | map(.price + 10)`) on a small (4kb) JSON file
 ```
-jq          0.02 real         0.02 user         0.00 sys
-query-json  0.00 real         0.00 user         0.00 sys
+query-json        0.00 real         0.00 user         0.00 sys
+jq                0.02 real         0.02 user         0.00 sys
+faq               0.06 real         0.04 user         0.01 sys
 ```
-### Simple operation on a medium (132k) JSON file
+
+### Simple operation (`map(.time)`) on a medium (132k) JSON file
 ```
-jq          0.03 real         0.03 user         0.00 sys
-query-json  0.01 real         0.00 user         0.00 sys
+query-json        0.01 real         0.00 user         0.00 sys
+jq                0.03 real         0.03 user         0.00 sys
+faq               0.07 real         0.07 user         0.00 sys
+fx                0.08 real         0.08 user         0.01 sys
 ```
-### Simple operation an attribute on a big JSON (604k) file
+
+### Simple operation (`map(select(.base.Attack > 100)) | map(.name.english)`) an attribute on a big JSON (604k) file
 ```
-jq          0.05 real         0.05 user         0.00 sys
-query-json  0.01 real         0.01 user         0.00 sys
+query-json        0.01 real         0.01 user         0.00 sys
+jq                0.05 real         0.05 user         0.00 sys
+faq               0.10 real         0.09 user         0.01 sys
 ```
-### Simple operation an attribute on a huge JSON (110M) file
+
+### Simple operation (`keys`) an attribute on a huge JSON (110M) file
 ```
-jq          2.58 real         2.33 user         0.23 sys
-query-json  2.23 real         2.09 user         0.13 sys
+query-json        2.17 real         2.04 user         0.12 sys
+jq                2.47 real         2.25 user         0.21 sys
+faq               6.22 real         6.79 user         0.56 sys
+fx                6.80 real        10.38 user         0.54 sys
 ```
 
 ## Explanation
 
-There are a few good asumtions about why **query-json** is faster, there are just speculations since I didn't profile neither jq, neither query-json.
+There are a few good asumtions about why **query-json** is faster, there are just speculations since I didn't profile any of the tools listed here, neither query-json.
+
+Thoughts about jq:
 
 The feature that I think penalizes a lot jq is "def functions", the capacity of define any function that can be available during run-time.
 
@@ -80,3 +145,14 @@ I will dig more into performance in [here](https://github.com/davesnx/query-json
 [jq Internals: backtracking](https://github.com/stedolan/jq/wiki/Internals:-backtracking)
 [jq Internals: the linker](https://github.com/stedolan/jq/wiki/Internals:-the-linker)
 [jq Internals: thestack](https://github.com/stedolan/jq/wiki/Internals:-the-stack)
+
+#### faq - Format Agnostic jQ
+Written in go
+https://github.com/jzelinskie/faq
+
+#### fx - Command-line tool and terminal JSON viewer 🔥
+Written in JavaScript
+https://github.com/antonmedv/fx
+
+## Please open an issue if you want to see here any jq-like tool
+If the queries match 1-to-1 to jq would be cool, otherwise could you add some examples.

--- a/benchmarks/report.md
+++ b/benchmarks/report.md
@@ -9,70 +9,71 @@ Executing `$ ./benchmarks/run.sh` runs both steps.
 
 `$ ./benchmarks/run.sh`
 
+```bash
 query-json: 0.5.8
 jq: jq-1.6
 faq: 0.0.6
 fx: 20.0.2
-
-### Benchmark #1: jq . esy.json
 ```
+
+#### Benchmark #1: jq . esy.json
+```bash
   Time (mean ± σ):      27.6 ms ±   1.0 ms    [User: 25.4 ms, System: 1.2 ms]
   Range (min … max):    26.5 ms …  32.1 ms    71 runs
 ```
 
-### Benchmark #1: query-json . esy.json
-```
+#### Benchmark #1: query-json . esy.json
+```bash
   Time (mean ± σ):       7.8 ms ±   0.2 ms    [User: 3.4 ms, System: 2.1 ms]
   Range (min … max):     7.3 ms …   8.9 ms    267 runs
 ```
-### Benchmark #2: jq . esy.json
-```
+#### Benchmark #2: jq . esy.json
+```bash
   Time (mean ± σ):      27.6 ms ±   1.1 ms    [User: 25.3 ms, System: 1.2 ms]
   Range (min … max):    26.4 ms …  34.5 ms    98 runs
 ```
-## **Summary** `query-json . esy.json` ran 3.56 ± 0.18 times faster than `jq . esy.json`
+### **Summary** `query-json . esy.json` ran 3.56 ± 0.18 times faster than `jq . esy.json`
 
-### Benchmark #1: faq . esy.json
-```
+#### Benchmark #1: faq . esy.json
+```bash
   Time (mean ± σ):      55.1 ms ±   0.6 ms    [User: 54.5 ms, System: 5.1 ms]
   Range (min … max):    53.9 ms …  57.2 ms    43 runs
 ```
-### Benchmark #1: query-json . esy.json
-```
+#### Benchmark #1: query-json . esy.json
+```bash
   Time (mean ± σ):       7.8 ms ±   0.2 ms    [User: 3.4 ms, System: 2.1 ms]
   Range (min … max):     7.3 ms …   8.9 ms    280 runs
 ```
-### Benchmark #2: faq . esy.json
-```
+#### Benchmark #2: faq . esy.json
+```bash
   Time (mean ± σ):      55.2 ms ±   0.7 ms    [User: 54.8 ms, System: 5.2 ms]
   Range (min … max):    53.9 ms …  57.2 ms    51 runs
 ```
-## **Summary** `query-json . esy.json` ran 7.11 ± 0.23 times faster than `faq . esy.json`
+### **Summary** `query-json . esy.json` ran 7.11 ± 0.23 times faster than `faq . esy.json`
 
-### Benchmark #1: fx esy.json .
-```
+#### Benchmark #1: fx esy.json .
+```bash
   Time (mean ± σ):      60.5 ms ±   1.8 ms    [User: 48.6 ms, System: 13.3 ms]
   Range (min … max):    59.1 ms …  70.9 ms    40 runs
 ```
-### Benchmark #1: query-json . esy.json
-```
+#### Benchmark #1: query-json . esy.json
+```bash
   Time (mean ± σ):       7.8 ms ±   0.2 ms    [User: 3.4 ms, System: 2.1 ms]
   Range (min … max):     7.4 ms …   8.8 ms    256 runs
 ```
-### Benchmark #2: fx esy.json .
-```
+#### Benchmark #2: fx esy.json .
+```bash
   Time (mean ± σ):      60.3 ms ±   0.6 ms    [User: 48.5 ms, System: 12.9 ms]
   Range (min … max):    59.3 ms …  62.1 ms    47 runs
 ```
-## **Summary** `query-json . esy.json` ran 7.73 ± 0.24 times faster than `fx esy.json .`
+### **Summary** `query-json . esy.json` ran 7.73 ± 0.24 times faster than `fx esy.json .`
 
 ---
 
 ## Running [run.sh](./run.sh)
 
 ### Select an attribute (`.first.id`) on a small (4kb) JSON file
-
-```
+```bash
 query-json        0.00 real         0.00 user         0.00 sys
 jq                0.02 real         0.02 user         0.00 sys
 faq               0.05 real         0.05 user         0.00 sys
@@ -80,14 +81,14 @@ fx                0.06 real         0.04 user         0.01 sys
 ```
 
 ### Select an attribute (`.`) on a medium (132k) JSON file
-```
+```bash
 query-json        0.02 real         0.01 user         0.00 sys
 jq                0.04 real         0.03 user         0.00 sys
 faq               0.07 real         0.08 user         0.00 sys
 fx                0.11 real         0.12 user         0.02 sys
 ```
 ### Map an attribute (`map(.)`) on a big JSON (604k) file
-```
+```bash
 query-json        0.07 real         0.06 user         0.00 sys
 jq                0.08 real         0.07 user         0.00 sys
 faq               0.12 real         0.14 user         0.01 sys
@@ -95,14 +96,14 @@ fx                0.17 real         0.20 user         0.02 sys
 ```
 
 ### Simple operation (`.second.store.books | map(.price + 10)`) on a small (4kb) JSON file
-```
+```bash
 query-json        0.00 real         0.00 user         0.00 sys
 jq                0.02 real         0.02 user         0.00 sys
 faq               0.06 real         0.04 user         0.01 sys
 ```
 
 ### Simple operation (`map(.time)`) on a medium (132k) JSON file
-```
+```bash
 query-json        0.01 real         0.00 user         0.00 sys
 jq                0.03 real         0.03 user         0.00 sys
 faq               0.07 real         0.07 user         0.00 sys
@@ -110,14 +111,14 @@ fx                0.08 real         0.08 user         0.01 sys
 ```
 
 ### Simple operation (`map(select(.base.Attack > 100)) | map(.name.english)`) an attribute on a big JSON (604k) file
-```
+```bash
 query-json        0.01 real         0.01 user         0.00 sys
 jq                0.05 real         0.05 user         0.00 sys
 faq               0.10 real         0.09 user         0.01 sys
 ```
 
 ### Simple operation (`keys`) an attribute on a huge JSON (110M) file
-```
+```bash
 query-json        2.17 real         2.04 user         0.12 sys
 jq                2.47 real         2.25 user         0.21 sys
 faq               6.22 real         6.79 user         0.56 sys

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -8,15 +8,23 @@ title () {
   echo "$2"
 }
 
-title "## Running benchmark tests..."
-jq --version
-query-json --version
-faq --version
-fx --version
+title "Running benchmark tests..."
+echo "query-json: $(query-json --version)"
+echo "jq: $(jq --version)"
+echo "faq: $(faq --version)"
+echo "fx: $(fx --version)"
+echo ""
 
 test () {
   /usr/bin/time "$@"
 }
+
+hyperfine --prepare 'query-json . esy.json' 'jq . esy.json'
+hyperfine 'query-json . esy.json' 'jq . esy.json'
+hyperfine --prepare 'query-json . esy.json' 'faq . esy.json'
+hyperfine 'query-json . esy.json' 'faq . esy.json'
+hyperfine --prepare 'query-json . esy.json' 'fx esy.json .'
+hyperfine 'query-json . esy.json' 'fx esy.json .'
 
 touch $trash;
 

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -11,7 +11,9 @@ title () {
 title "## Running benchmark tests..."
 # pxi --version
 jq --version
-q --version
+query-json --version
+faq --version
+rq --version
 
 test () {
   /usr/bin/time "$@"
@@ -19,37 +21,50 @@ test () {
 
 title "### Select an attribute on a small (4kb) JSON file" ".first.id"
 # test pxi 'json => json.first.id' < benchmarks/small.json > $trash
-test jq '.first.id' benchmarks/small.json > $trash
-test q '.first.id' benchmarks/small.json > $trash
+test jq '.first.id' benchmarks/small.json >> $trash
+test query-json '.first.id' benchmarks/small.json >> $trash
+test faq '.first.id' benchmarks/small.json >> $trash
+test rq '.first.id' benchmarks/small.json >> $trash
 
 title "### Select an attribute on a medium (132k) JSON file" "."
 # test pxi 'json => json.map(item => item.time)' < benchmarks/medium.json > $trash
 test jq '.' benchmarks/medium.json > $trash
-test q '.' benchmarks/medium.json > $trash
+test query-json '.' benchmarks/medium.json > $trash
+test faq '.' benchmarks/medium.json > $trash
+test rq '.' benchmarks/medium.json > $trash
 
 title "### Select an attribute on a big JSON (604k) file" "map(.)"
 # test pxi 'json => Object.keys(json)' < benchmarks/big.json > $trash
 test jq 'map(.)' benchmarks/big.json > $trash
-test q 'map(.)' benchmarks/big.json > $trash
+test query-json 'map(.)' benchmarks/big.json > $trash
+test faq 'map(.)' benchmarks/big.json > $trash
+test rq 'map(.)' benchmarks/big.json > $trash
 
 title "### Simple operation on a small (4kb) JSON file" ".second.store.books | map(.price + 10)"
 # test pxi 'json => json.time' < benchmarks/small.json
 test jq '.second.store.books | map(.price + 10)' benchmarks/small.json > $trash
-test q '.second.store.books | map(.price + 10)' benchmarks/small.json > $trash
+test query-json '.second.store.books | map(.price + 10)' benchmarks/small.json > $trash
+test rq '.second.store.books | map(.price + 10)' benchmarks/small.json > $trash
 
 title "### Simple operation on a medium (132k) JSON file" "map(.time)"
 # test pxi 'json => json.first.id' < benchmarks/medium.json > $trash
 test jq 'map(.time)' benchmarks/medium.json > $trash
-test q 'map(.time)' benchmarks/medium.json > $trash
+test query-json 'map(.time)' benchmarks/medium.json > $trash
+test faq 'map(.time)' benchmarks/medium.json > $trash
+test rq 'map(.time)' benchmarks/medium.json > $trash
 
 title "### Simple operation an attribute on a big JSON (604k) file" "map(select(.base.Attack > 100)) | map(.name.english)"
 # test pxi 'json => json.time' < benchmarks/big.json > $trash
 test jq 'map(select(.base.Attack > 100)) | map(.name.english)' benchmarks/big.json > $trash
-test q 'filter(.base."Attack" > 100) | map(.name.english)' benchmarks/big.json > $trash
+test query-json 'filter(.base."Attack" > 100) | map(.name.english)' benchmarks/big.json > $trash
+# test faq 'filter(.base."Attack" > 100) | map(.name.english)' benchmarks/big.json > $trash
+# test rq 'filter(.base."Attack" > 100) | map(.name.english)' benchmarks/big.json > $trash
 
 title "### Simple operation an attribute on a huge JSON (110M) file" "keys"
 # test pxi 'json => json.time' < benchmarks/huge.json > $trash
 test jq 'keys' benchmarks/huge.json > $trash
-test q 'keys' benchmarks/huge.json > $trash
+test query-json 'keys' benchmarks/huge.json > $trash
+test faq 'keys' benchmarks/huge.json > $trash
+test rq 'keys' benchmarks/huge.json > $trash
 
 rm $trash

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -9,62 +9,62 @@ title () {
 }
 
 title "## Running benchmark tests..."
-# pxi --version
 jq --version
 query-json --version
 faq --version
-rq --version
+fx --version
 
 test () {
   /usr/bin/time "$@"
 }
 
+touch $trash;
+
 title "### Select an attribute on a small (4kb) JSON file" ".first.id"
-# test pxi 'json => json.first.id' < benchmarks/small.json > $trash
-test jq '.first.id' benchmarks/small.json >> $trash
 test query-json '.first.id' benchmarks/small.json >> $trash
+test jq '.first.id' benchmarks/small.json >> $trash
 test faq '.first.id' benchmarks/small.json >> $trash
-test rq '.first.id' benchmarks/small.json >> $trash
+test fx benchmarks/small.json '.first.id' >> $trash
 
 title "### Select an attribute on a medium (132k) JSON file" "."
-# test pxi 'json => json.map(item => item.time)' < benchmarks/medium.json > $trash
-test jq '.' benchmarks/medium.json > $trash
-test query-json '.' benchmarks/medium.json > $trash
-test faq '.' benchmarks/medium.json > $trash
-test rq '.' benchmarks/medium.json > $trash
+#
+test query-json '.' benchmarks/medium.json >> $trash
+test jq '.' benchmarks/medium.json >> $trash
+test faq '.' benchmarks/medium.json >> $trash
+test fx benchmarks/medium.json '.' >> $trash
 
 title "### Select an attribute on a big JSON (604k) file" "map(.)"
-# test pxi 'json => Object.keys(json)' < benchmarks/big.json > $trash
-test jq 'map(.)' benchmarks/big.json > $trash
-test query-json 'map(.)' benchmarks/big.json > $trash
-test faq 'map(.)' benchmarks/big.json > $trash
-test rq 'map(.)' benchmarks/big.json > $trash
+#
+test query-json 'map(.)' benchmarks/big.json >> $trash
+test jq 'map(.)' benchmarks/big.json >> $trash
+test faq 'map(.)' benchmarks/big.json >> $trash
+test fx benchmarks/big.json '.map(x => x)' >> $trash
 
 title "### Simple operation on a small (4kb) JSON file" ".second.store.books | map(.price + 10)"
-# test pxi 'json => json.time' < benchmarks/small.json
-test jq '.second.store.books | map(.price + 10)' benchmarks/small.json > $trash
-test query-json '.second.store.books | map(.price + 10)' benchmarks/small.json > $trash
-test rq '.second.store.books | map(.price + 10)' benchmarks/small.json > $trash
+#
+test query-json '.second.store.books | map(.price + 10)' benchmarks/small.json >> $trash
+test jq '.second.store.books | map(.price + 10)' benchmarks/small.json >> $trash
+test fx benchmarks/small.json '.second.store.books.map(x => x.price + 10)' >> $trash
 
 title "### Simple operation on a medium (132k) JSON file" "map(.time)"
-# test pxi 'json => json.first.id' < benchmarks/medium.json > $trash
-test jq 'map(.time)' benchmarks/medium.json > $trash
-test query-json 'map(.time)' benchmarks/medium.json > $trash
-test faq 'map(.time)' benchmarks/medium.json > $trash
-test rq 'map(.time)' benchmarks/medium.json > $trash
+#
+test query-json 'map(.time)' benchmarks/medium.json >> $trash
+test jq 'map(.time)' benchmarks/medium.json >> $trash
+test faq 'map(.time)' benchmarks/medium.json >> $trash
+test fx benchmarks/medium.json '.map(x => x.time)' >> $trash
 
 title "### Simple operation an attribute on a big JSON (604k) file" "map(select(.base.Attack > 100)) | map(.name.english)"
-# test pxi 'json => json.time' < benchmarks/big.json > $trash
-test jq 'map(select(.base.Attack > 100)) | map(.name.english)' benchmarks/big.json > $trash
-test query-json 'filter(.base."Attack" > 100) | map(.name.english)' benchmarks/big.json > $trash
-# test faq 'filter(.base."Attack" > 100) | map(.name.english)' benchmarks/big.json > $trash
-# test rq 'filter(.base."Attack" > 100) | map(.name.english)' benchmarks/big.json > $trash
+#
+test query-json 'filter(.base."Attack" > 100) | map(.name.english)' benchmarks/big.json >> $trash
+test jq 'map(select(.base.Attack > 100)) | map(.name.english)' benchmarks/big.json >> $trash
+# test faq 'filter(.base."Attack" > 100) | map(.name.english)' benchmarks/big.json >> $trash
+test fx benchmarks/big.json '.filter(x => x.base["Attack"] > 100).map(x => x.name.english)' >> $trash
 
 title "### Simple operation an attribute on a huge JSON (110M) file" "keys"
-# test pxi 'json => json.time' < benchmarks/huge.json > $trash
-test jq 'keys' benchmarks/huge.json > $trash
-test query-json 'keys' benchmarks/huge.json > $trash
-test faq 'keys' benchmarks/huge.json > $trash
-test rq 'keys' benchmarks/huge.json > $trash
+#
+test query-json 'keys' benchmarks/huge.json >> $trash
+test jq 'keys' benchmarks/huge.json >> $trash
+test faq 'keys' benchmarks/huge.json >> $trash
+test fx benchmarks/huge.json 'Object.keys' >> $trash
 
 rm $trash


### PR DESCRIPTION
https://github.com/davesnx/query-json/issues/11

- https://github.com/borkdude/jet - WIP
- https://github.com/TomConlin/json2xpath - Uses jq under the hood.
- https://github.com/antonmedv/fx - Added:	'query-json . esy.json' ran 7.84 ± 0.51 times faster than 'fx esy.json .'
- https://github.com/fiatjaf/jiq - It's interactive, fork of jid
- https://github.com/simeji/jid - It's interactive.
- https://github.com/jmespath/jp - Crash on run a basic filter.
- https://github.com/cube2222/jql - Doesn't have reading from file, didn't add on the benchmarks, but I run it once: 'cat esy.json | query-json --kind=inline .' ran 1.00 ± 0.07 times faster than 'cat esy.json | jql'. Similar results when using stdin.
- https://jsonnet.org - Doesn't apply
- https://github.com/jzelinskie/faq - Added: 'query-json . esy.json' ran 6.96 ± 1.22 times faster than 'faq . esy.json'
- https://github.com/dflemstr/rq - Coudn't figure out the 1to1 queries.

See the new report here: https://github.com/davesnx/query-json/blob/Add-more-benchmarks/benchmarks/report.md