### PR TITLE
Bring query-json closer to jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This would access to `"store"` field inside the **stores.json**, access to `"boo
   - `verbose` flag, prints each operation in each state and it's intermediate states. _(Work in progress...)_
 - **Improved API**: made small adjustments to the buildin operations. Some examples are:
   - All methods are snake_case instead of alltoghetercase
-  - Changed `select` for `filter`
+  - Added `filter(p)` as an alias for `map(select(p))`
   - Supports comments in JSONs
 - **Small**: Lexer, Parser and Compiler are just 300 LOC and most of the commands that I use on my day to day are implemented in only 140 LOC.
 
@@ -137,9 +137,9 @@ The report shows that **query-json** is between 2x and 5x faster than **jq** in 
   - Array Index: `.[2]` ✅
   - Pipe: `|` ✅
   - Array/String Slice: `.[10:15]` ⚠️
-  - Array/Object Value Iterator: `.[]` 🔴
-  - Comma: `,` ⚠️
-  - Parenthesis: `()` ⚠️
+  - Array/Object Value Iterator: `.[]` ✅
+  - Comma: `,` ✅
+  - Parenthesis: `()` ✅️
 
 - #### [Types and Values](https://stedolan.github.io/jq/manual/v1.6/#TypesandValues) ⚠️
 
@@ -151,7 +151,7 @@ The report shows that **query-json** is between 2x and 5x faster than **jq** in 
   - `length` ✅
   - `keys` ✅
   - `map` ✅
-  - `select` it's renamed to `filter` and operates differently. Filter is an alias to `map(select())`. ✅
+  - `select` ✅
   - `has(key)` ⚠️
   - `in` ⚠️
   - `path(path_expression)` ⚠️

--- a/bin/Bin.re
+++ b/bin/Bin.re
@@ -40,9 +40,17 @@ let run =
        })
     |> Result.map(res =>
          res
-         |> Result.map(o =>
-              Source.Json.toString(o, ~colorize=!noColor, ~summarize=false)
-              |> print_endline
+         |> Result.map(os =>
+              List.iter(
+                o =>
+                  Source.Json.toString(
+                    o,
+                    ~colorize=!noColor,
+                    ~summarize=false,
+                  )
+                  |> print_endline,
+                os,
+              )
             )
          |> Result.map_error(e => print_endline(Errors.printError(e)))
        )

--- a/source/Ast.re
+++ b/source/Ast.re
@@ -11,11 +11,12 @@ type literal =
 [@deriving show]
 type expression =
   | Identity /* . */
+  | Empty /* empty */
   | Pipe(expression, expression) /* | */
-  | Comma /* , */
+  | Comma(expression, expression) /* expr1 , expr2 */
   | Literal(literal)
   /* Constructors */
-  | List(list(expression)) /* [] */
+  | List(expression) /* [ expr ] */
   | Object(list((string, expression))) /* {} */
   /* Objects */
   | Walk(expression) /* walk() */
@@ -45,8 +46,7 @@ type expression =
   | Nan
   | IsNan
   /* Array */
-  | Index(int) /* [1] */
-  | Filter(conditional) /* .filter(x) */
+  | Index(int) /* .[1] */
   | Range(int, int) /* range(1, 10) */
   | Flatten /* flatten */
   | Head /* head */
@@ -54,7 +54,7 @@ type expression =
   | Map(expression) /* .[] */ /* map(x) */
   | FlatMap(expression) /* flat_map(x) */
   | Reduce(expression) /* reduce(x) */
-  | Select(expression) /* .select(x) */
+  | Select(expression) /* select(x) */
   | SortBy(expression) /* sort_by(x) */
   | GroupBy(expression) /* group_by(x) */
   | UniqueBy(expression) /* unique_by(x) */
@@ -81,15 +81,14 @@ type expression =
   | Join(expression) /* join */
   | Path(expression) /* path(x) */
   /* Logic */
-  | If(conditional)
+  | If(expression)
   | Then(expression)
   | Else(expression)
   | Break
-
-and conditional =
+  /* Conditionals */
   | And(expression, expression) /* and */
   | Or(expression, expression) /* or */
-  | Not(expression, expression) /* ! */
+  | Not /* not */
   | Greater(expression, expression) /* > */
   | Lower(expression, expression) /* < */
   | GreaterEqual(expression, expression) /* >= */

--- a/source/Compiler.re
+++ b/source/Compiler.re
@@ -37,29 +37,67 @@ let makeError = (name: string, json: Json.t) => {
   };
 };
 
+let pure = x => Ok([x]);
+
+let empty = Ok([]);
+
+let lift2 =
+    (f: ('a, 'b) => 'c, mx: result('a, string), my: result('b, string))
+    : result('c, string) => {
+  switch (mx) {
+  | Ok(x) =>
+    switch (my) {
+    | Ok(y) => Ok(f(x, y))
+    | Error(err) => Error(err)
+    }
+  | Error(err) => Error(err)
+  };
+};
+
+let collect =
+    (xs: list(result(list('a), string))): result(list('a), string) =>
+  List.fold_right(lift2((@)), xs, empty);
+
+let bind =
+    (mx: result(list('a), string), f: 'a => result(list('b), string))
+    : result(list('b), string) => {
+  switch (mx) {
+  | Ok(xs) => collect(List.map(f, xs))
+  | Error(err) => Error(err)
+  };
+};
+
 let keys = (json: Json.t) => {
   switch (json) {
   | `Assoc(_list) =>
-    Ok(`List(Json.keys(json) |> List.map(i => `String(i))))
+    pure(`List(Json.keys(json) |> List.map(i => `String(i))))
   | _ => Error(makeError("keys", json))
   };
 };
 
 let length = (json: Json.t) => {
   switch (json) {
-  | `List(list) => Ok(`Int(list |> List.length))
+  | `List(list) => pure(`Int(list |> List.length))
   | _ => Error(makeError("length", json))
+  };
+};
+
+let not_ = (json: Json.t) => {
+  switch (json) {
+  | `Bool(false)
+  | `Null => pure(`Bool(true))
+  | _ => pure(`Bool(false))
   };
 };
 
 let apply =
     (str: string, fn: (float, float) => float, left: Json.t, right: Json.t) => {
   switch (left, right) {
-  | (`Float(l), `Float(r)) => Ok(`Float(fn(l, r)))
-  | (`Int(l), `Float(r)) => Ok(`Float(fn(float_of_int(l), r)))
-  | (`Float(l), `Int(r)) => Ok(`Float(fn(l, float_of_int(r))))
+  | (`Float(l), `Float(r)) => pure(`Float(fn(l, r)))
+  | (`Int(l), `Float(r)) => pure(`Float(fn(float_of_int(l), r)))
+  | (`Float(l), `Int(r)) => pure(`Float(fn(l, float_of_int(r))))
   | (`Int(l), `Int(r)) =>
-    Ok(`Float(fn(float_of_int(l), float_of_int(r))))
+    pure(`Float(fn(float_of_int(l), float_of_int(r))))
   | _ => Error(makeError(str, left))
   };
 };
@@ -67,10 +105,11 @@ let apply =
 let compare =
     (str: string, fn: (float, float) => bool, left: Json.t, right: Json.t) => {
   switch (left, right) {
-  | (`Float(l), `Float(r)) => Ok(fn(l, r))
-  | (`Int(l), `Float(r)) => Ok(fn(float_of_int(l), r))
-  | (`Float(l), `Int(r)) => Ok(fn(l, float_of_int(r)))
-  | (`Int(l), `Int(r)) => Ok(fn(float_of_int(l), float_of_int(r)))
+  | (`Float(l), `Float(r)) => pure(`Bool(fn(l, r)))
+  | (`Int(l), `Float(r)) => pure(`Bool(fn(float_of_int(l), r)))
+  | (`Float(l), `Int(r)) => pure(`Bool(fn(l, float_of_int(r))))
+  | (`Int(l), `Int(r)) =>
+    pure(`Bool(fn(float_of_int(l), float_of_int(r))))
   | _ => Error(makeError(str, right))
   };
 };
@@ -78,21 +117,21 @@ let compare =
 let condition =
     (str: string, fn: (bool, bool) => bool, left: Json.t, right: Json.t) => {
   switch (left, right) {
-  | (`Bool(l), `Bool(r)) => Ok(fn(l, r))
+  | (`Bool(l), `Bool(r)) => pure(`Bool(fn(l, r)))
   | _ => Error(makeError(str, right))
   };
 };
 
-let gt = compare(">", (l, r) => l > r);
-let gte = compare(">=", (l, r) => l >= r);
-let lt = compare("<", (l, r) => l < r);
-let lte = compare("<=", (l, r) => l <= r);
-let and_ = condition("and", (l, r) => l && r);
-let or_ = condition("or", (l, r) => l || r);
-let not_ = condition("not", (l, _) => !l);
+let gt = compare(">", (>));
+let gte = compare(">=", (>=));
+let lt = compare("<", (<));
+let lte = compare("<=", (<=));
+let and_ = condition("and", (&&));
+let or_ = condition("or", (||));
 
-let eq = condition("==", (l, r) => l == r);
-let notEq = condition("!=", (l, r) => l != r);
+/* Does OCaml equality on Json.t implies JSON equality? */
+let eq = (l, r) => pure(`Bool(l == r));
+let notEq = (l, r) => pure(`Bool(l != r));
 
 let add = apply("+", (l, r) => l +. r);
 let sub = apply("-", (l, r) => l -. r);
@@ -106,8 +145,6 @@ let filter = (fn: Json.t => bool, json: Json.t) => {
   };
 };
 
-let id: Json.t => Json.t = i => i;
-
 let makeEmptyListError = op => {
   "Trying to "
   ++ Formatting.singleQuotes(Chalk.bold(op))
@@ -118,7 +155,8 @@ let head = (json: Json.t) => {
   switch (json) {
   | `List(list) =>
     List.length(list) > 0
-      ? Ok(Json.index(0, `List(list))) : Error(makeEmptyListError("head"))
+      ? pure(Json.index(0, `List(list)))
+      : Error(makeEmptyListError("head"))
 
   | _ => Error(makeError("head", json))
   };
@@ -130,7 +168,7 @@ let tail = (json: Json.t) => {
     List.length(list) > 0
       ? {
         let lastIndex = List.length(list) - 1;
-        Ok(Json.index(lastIndex, `List(list)));
+        pure(Json.index(lastIndex, `List(list)));
       }
       : Error(makeEmptyListError("head"))
   | _ => Error(makeError("tail", json))
@@ -152,10 +190,10 @@ let member = (key: string, opt: bool, json: Json.t) => {
   | `Assoc(_assoc) =>
     let accessMember = Json.member(key, json);
     switch (accessMember, opt) {
-    | (`Null, true) => Ok(accessMember)
+    | (`Null, true) => pure(accessMember)
     | (`Null, false) => Error(makeErrorMissingMember("." ++ key, key, json))
-    | (_, false) => Ok(accessMember)
-    | (_, true) => Ok(accessMember)
+    | (_, false) => pure(accessMember)
+    | (_, true) => pure(accessMember)
     };
   | _ => Error(makeError("." ++ key, json))
   };
@@ -163,20 +201,23 @@ let member = (key: string, opt: bool, json: Json.t) => {
 
 let index = (value: int, json: Json.t) => {
   switch (json) {
-  | `List(_list) => Ok(Json.index(value, json))
+  | `List(_list) => pure(Json.index(value, json))
   | _ => Error(makeError("[" ++ string_of_int(value) ++ "]", json))
   };
 };
 
-let rec compile = (expression: expression, json): result(Json.t, string) => {
+let rec compile =
+        (expression: expression, json): result(list(Json.t), string) => {
   switch (expression) {
-  | Identity => Ok(id(json))
+  | Identity => pure(json)
+  | Empty => empty
   | Keys => keys(json)
   | Key(key, opt) => member(key, opt, json)
   | Index(idx) => index(idx, json)
   | Head => head(json)
   | Tail => tail(json)
   | Length => length(json)
+  | Not => not_(json)
   | Map(expr) => map(expr, json)
   | Addition(left, right) => operation(left, right, add, json)
   | Subtraction(left, right) => operation(left, right, sub, json)
@@ -184,72 +225,46 @@ let rec compile = (expression: expression, json): result(Json.t, string) => {
   | Division(left, right) => operation(left, right, div, json)
   | Literal(literal) =>
     switch (literal) {
-    | Bool(b) => Ok(`Bool(b))
-    | Number(float) => Ok(`Float(float))
-    | String(string) => Ok(`String(string))
-    | Null => Ok(`Null)
+    | Bool(b) => pure(`Bool(b))
+    | Number(float) => pure(`Float(float))
+    | String(string) => pure(`String(string))
+    | Null => pure(`Null)
     }
-  | Pipe(left, right) =>
-    let cLeft = compile(left, json);
-    switch (cLeft) {
-    | Ok(l) => compile(right, l)
-    | Error(err) => Error(err)
-    };
-  | Filter(conditional) =>
-    filter(
-      item => {
-        switch (conditional) {
-        | Greater(left, right) => condition(left, right, gt, item)
-        | GreaterEqual(left, right) => condition(left, right, gte, item)
-        | Lower(left, right) => condition(left, right, lt, item)
-        | LowerEqual(left, right) => condition(left, right, lte, item)
-        | Equal(left, right) => condition(left, right, eq, item)
-        | NotEqual(left, right) => condition(left, right, notEq, item)
-        | And(left, right) => condition(left, right, and_, item)
-        | Or(left, right) => condition(left, right, or_, item)
-        | Not(left, right) => condition(left, right, not_, item)
-        }
-      },
-      json,
+  | Pipe(left, right) => bind(compile(left, json), compile(right))
+  | Select(conditional) =>
+    bind(compile(conditional, json), res =>
+      switch (res) {
+      | `Bool(b) => b ? pure(json) : empty
+      | _ => Error(makeError("select", res))
+      }
     )
-  | List([]) =>
-    let alias = Pipe(Identity, Map(Identity));
-    compile(alias, json);
+  | Greater(left, right) => operation(left, right, gt, json)
+  | GreaterEqual(left, right) => operation(left, right, gte, json)
+  | Lower(left, right) => operation(left, right, lt, json)
+  | LowerEqual(left, right) => operation(left, right, lte, json)
+  | Equal(left, right) => operation(left, right, eq, json)
+  | NotEqual(left, right) => operation(left, right, notEq, json)
+  | And(left, right) => operation(left, right, and_, json)
+  | Or(left, right) => operation(left, right, or_, json)
+  | List(expr) => Result.bind(compile(expr, json), xs => pure(`List(xs)))
+  | Comma(leftR, rightR) =>
+    Result.bind(compile(leftR, json), left =>
+      Result.bind(compile(rightR, json), right => Ok(left @ right))
+    )
   | _ => Error(show_expression(expression) ++ " is not implemented")
   };
 }
 and operation = (leftR, rightR, op, json) => {
-  let exprLeft = compile(leftR, json);
-  let exprRight = compile(rightR, json);
-
-  switch (exprLeft, exprRight) {
-  | (Ok(left), Ok(right)) => op(left, right)
-  | (Error(err), _) => Error(err)
-  | (_, Error(err)) => Error(err)
-  };
-}
-and condition = (leftR, rightR, op, json) => {
-  let exprLeft = compile(leftR, json);
-  let exprRight = compile(rightR, json);
-
-  switch (exprLeft, exprRight) {
-  | (Ok(left), Ok(right)) =>
-    switch (op(left, right)) {
-    | Ok(boolean) => boolean
-    /* If the condition fails, return false */
-    | Error(_err) => false
-    }
-  | (Error(_err), _) => false
-  | (_, Error(_err)) => false
-  };
+  bind(compile(leftR, json), left =>
+    bind(compile(rightR, json), right => op(left, right))
+  );
 }
 and map = (expr: expression, json: Json.t) => {
   switch (json) {
   | `List(list) =>
-    /* TODO: compiler(expr, item) |> Result.get_ok can raise exn */
     List.length(list) > 0
       ? {
-        Ok(Json.map(item => compile(expr, item) |> Result.get_ok, json));
+        collect(List.map(item => compile(expr, item), list));
       }
       : Error(makeEmptyListError("map"))
   | _ => Error(makeError("map", json))

--- a/source/Tokenizer.re
+++ b/source/Tokenizer.re
@@ -13,13 +13,13 @@ type token =
   | BOOL(bool)
   | IDENTIFIER(string)
   | FUNCTION(string)
+  | OPEN_PARENT
   | CLOSE_PARENT
   | OPEN_BRACKET
   | CLOSE_BRACKET
   | OPEN_BRACE
   | SEMICOLON
   | CLOSE_BRACE
-  | EXCLAMATION_MARK
   | DOT
   | DOUBLE_DOT
   | RECURSE
@@ -77,7 +77,6 @@ let rec tokenize = buf => {
   | "!=" => Ok(NOT_EQUAL)
   | "+" => Ok(ADD)
   | "and" => Ok(AND)
-  | "!" => Ok(EXCLAMATION_MARK)
   | "or" => Ok(OR)
   | "-" => Ok(SUB)
   | "*" => Ok(MULT)
@@ -93,6 +92,7 @@ let rec tokenize = buf => {
   | "null" => Ok(NULL)
   | "true" => Ok(BOOL(true))
   | "false" => Ok(BOOL(false))
+  | "(" => Ok(OPEN_PARENT)
   | ")" => Ok(CLOSE_PARENT)
   | dot => Ok(DOT)
   | ':' => Ok(DOUBLE_DOT)

--- a/test/ParseTest.re
+++ b/test/ParseTest.re
@@ -9,13 +9,13 @@ let compare = (expected, result, {expect, _}) => {
 };
 
 let tests: list((string, expression)) = [
-  /* (".[1]", Pipe(Identity, Index(1))), */
-  (". | [1]", Pipe(Identity, Index(1))),
+  (".[1]", Pipe(Identity, Index(1))),
+  ("[1]", List(Literal(Number(1.)))),
   (".store.books", Pipe(Key("store", false), Key("books", false))),
   (".books[1]", Pipe(Key("books", false), Index(1))),
   (
     ".books[1].author",
-    Pipe(Key("books", false), Pipe(Index(1), Key("author", false))),
+    Pipe(Pipe(Key("books", false), Index(1)), Key("author", false)),
   ),
   (".store", Key("store", false)),
   (".", Identity),
@@ -30,6 +30,20 @@ let tests: list((string, expression)) = [
   (".WAT", Key("WAT", false)),
   ("head", Head),
   (".WAT?", Key("WAT", true)),
+  ("1, 2", Comma(Literal(Number(1.)), Literal(Number(2.)))),
+  ("empty", Empty),
+  (
+    "(1, 2) + 3",
+    Addition(
+      Comma(Literal(Number(1.)), Literal(Number(2.))),
+      Literal(Number(3.)),
+    ),
+  ),
+  ("[1, 2]", List(Comma(Literal(Number(1.)), Literal(Number(2.))))),
+  ("select(true)", Select(Literal(Bool(true)))),
+  ("[1][0]", Pipe(List(Literal(Number(1.))), Index(0))),
+  ("[1].foo", Pipe(List(Literal(Number(1.))), Key("foo", false))),
+  ("(empty).foo?", Pipe(Empty, Key("foo", true))),
 ];
 
 describe("correctly parse value", ({test, _}) => {


### PR DESCRIPTION
* Internally filters can now emit multiple outputs.
* These constructs are now supported:
  + empty
  + expr1 , expr2
  + (expr)
  + [expr]
  + select(expr)
  + not
* filter(e) is now a shortcut for map(select(p))
* Conditional are just expressions (they return a JSON boolean value).
* Extend == and != to all JSON values
* Fix priorities according to jq
* Fix paths: .foo[4] and .[4] are paths [4] is not a path
* Fix the parser to follow better the jq grammar
     (expr vs term, no conditionals, no paths)
* Extend parsing tests