### PR TITLE
fix init script, update readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist
 
 # Vite build
 build
+
+# local opam switch
+_opam

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ build-prod: ## Build for production (--profile=prod)
 dev: ## Build in watch mode
 	$(DUNE) build -w @all
 
+.PHONY: dev-core
+dev-core: ## Build in watch mode
+	$(DUNE) build -w source
+
 .PHONY: web-dev
 web-dev: ## Build and serve the website via HMR
 	$(NPX) vite --host --config website/vite.config.js
@@ -80,4 +84,4 @@ npm-install: ## Install npm dependencies
 	npm install
 
 .PHONY: init
-init: setup-githooks create-switch pin install install-npm ## Create a local dev enviroment
+init: setup-githooks create-switch pin install npm-install ## Create a local dev enviroment

--- a/README.md
+++ b/README.md
@@ -190,7 +190,16 @@ Requirements: [opam](https://opam.ocaml.org)
 git clone https://github.com/davesnx/query-json
 cd query-json
 make init # creates opam switch, installs ocaml deps and npm deps
-make dev # compiles
+```
+
+Core query-json setup
+```bash
+make dev-core # compiles query-json only
+```
+
+All packages setup
+```bash
+make dev # compiles all opam packages
 make test # runs unit tests and snapshots tests
 dune exec query-json # Run binary
 ```


### PR DESCRIPTION
Fixed: 
- Init creates an `_opam` folder for the switch which isn't in the `.gitignore` file.
- the makefile target was pointing to `install-npm` instead of `npm-install`.

I have updated the readme with instructions to work only on the core query-json package, or to compile all the opam packages simultaneously.