### PR TITLE
Put name in dune-project

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -3,6 +3,8 @@
 (using menhir 2.0)
 (using melange 0.1)
 
+(name query-json)
+
 (generate_opam_files true)
 
 (license MIT)


### PR DESCRIPTION
Dear @davesnx, thank you for your work on query-json!

I was trying to have your project as a dependency of a project of mine, because I am considering calling your APIs programmatically (maybe this is dumb idea, but it seems to fit my use case well). When doing so, I ran into this silly issue that `dune` insists for the project to have a `name` in the top-level `dune-project` file when building it (that's because [dune subst](https://dune.readthedocs.io/en/latest/usage.html#dune-subst) needs it):

```
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
⬇ retrieved query-json.dev  (no changes)
[ERROR] The compilation of query-json.dev failed at "dune subst".

#=== ERROR while compiling query-json.dev =====================================#
# context     2.4.1 | linux/x86_64 | ocaml-base-compiler.5.3.0 | pinned(git+https://github.com/davesnx/query-json.git#0.5.21#1abc400605d5547610ffc803144e6dda5c2faff3)
# path        ~/dev/stratocaml/_opam/.opam-switch/build/query-json.dev
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune subst
# exit-code   1
# env-file    ~/.opam/log/query-json-1497027-fbc0dc.env
# output-file ~/.opam/log/query-json-1497027-fbc0dc.out
### output ###
# File "dune-project", line 1, characters 0-0:
# Error: The project name is not defined, please add a (name <name>) field to
# your dune-project file.
```

As a consequence, to make it just a bit easier for people to consume your code as a dependency, I'm adding `name` to the top-level of the `dune-project` file with this PR.