### PR TITLE
Fixes install script link

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The old jq names still work but show deprecation warnings. See the full [jq Comp
 
 Check the content of [scripts/install.sh](./scripts/install.sh) before running anything in your local. [Friends don't let friends curl | bash](https://sysdig.com/blog/friends-dont-let-friends-curl-bash).
 ```bash
-curl -sfL https://query-json.page.dev/install.sh | bash
+curl -sfL https://query-json.pages.dev/install.sh | bash
 ```
 
 ### Using npm


### PR DESCRIPTION
I was looking to try out this tool but couldn't work out why nothing was showing up on the path after running it a couple of times.

Once I removed the curl -s flag I realised it couldn't resolve the host, which I realised was just due to an incorrect URL with `page` vs `pages`.

At least I have it now!