### PR TITLE
Update dune-release-action to v0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,7 +422,7 @@ jobs:
 
       - name: Publish to opam
         if: matrix.os == 'ubuntu-latest' && startsWith(github.ref, 'refs/tags/')
-        uses: davesnx/dune-release-action@v0.2.1
+        uses: davesnx/dune-release-action@v0.4.0
         with:
           packages: 'query-json'
           changelog: './CHANGES.md'


### PR DESCRIPTION
Updates `dune-release-action` to [v0.4.0](https://github.com/davesnx/dune-release-action/blob/main/CHANGES.md).

Notable changes since older versions:

- New `pr-preamble-message` input to prepend custom text to the opam-repository PR description
- Fix `publish-message` input (previously passed as an unrecognized `--msg` flag, which failed the publish step when set)
- Action runtime upgraded to Node.js 24
- `dune-release-action/lint` sub-action for branch/PR linting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
